### PR TITLE
Improve how labels are copied. Include vendor & name

### DIFF
--- a/controllers/clusterclaims/clusterclaims-controller.go
+++ b/controllers/clusterclaims/clusterclaims-controller.go
@@ -108,6 +108,7 @@ func createManagedCluster(r *ClusterClaimsReconciler, claimName string, target s
 		newLabels := map[string]string{}
 		if labels != nil {
 			for key, val := range labels {
+				log.V(DEBUG).Info("Copy label: " + key)
 				newLabels[key] = val
 			}
 		}

--- a/controllers/clusterclaims/clusterclaims-controller.go
+++ b/controllers/clusterclaims/clusterclaims-controller.go
@@ -118,7 +118,7 @@ func createManagedCluster(r *ClusterClaimsReconciler, claimName string, target s
 		}
 		newLabels["vendor"] = "OpenShift" // This is always true
 		//TODO: Add region lookup. It is a label on the ClusterDeployment or ClusterPool
-		mc.ObjectMeta.Labels = labels
+		mc.ObjectMeta.Labels = newLabels
 
 		if err = r.Create(ctx, &mc, &client.CreateOptions{}); err != nil {
 
@@ -148,6 +148,7 @@ func createKlusterletAddonConfig(r *ClusterClaimsReconciler, target string) (ctr
 		kac.Namespace = target
 		kac.Spec.ClusterName = target
 		kac.Spec.ClusterNamespace = target
+		kac.Spec.ClusterLabels = map[string]string{"vendor": "OpenShift"} // Required for object to be created
 		kac.Spec.ApplicationManagerConfig.Enabled = true
 		kac.Spec.CertPolicyControllerConfig.Enabled = true
 		kac.Spec.IAMPolicyControllerConfig.Enabled = true

--- a/controllers/clusterclaims/clusterclaims-controller.go
+++ b/controllers/clusterclaims/clusterclaims-controller.go
@@ -65,7 +65,7 @@ func (r *ClusterClaimsReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 	}
 
 	// ManagedCluster
-	if res, err := createManagedCluster(r, target, cc.Labels); err != nil {
+	if res, err := createManagedCluster(r, cc.Name, target, cc.Labels); err != nil {
 		return res, err
 	}
 
@@ -92,7 +92,7 @@ func (r *ClusterClaimsReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}).Complete(r)
 }
 
-func createManagedCluster(r *ClusterClaimsReconciler, target string, labels map[string]string) (ctrl.Result, error) {
+func createManagedCluster(r *ClusterClaimsReconciler, claimName string, target string, labels map[string]string) (ctrl.Result, error) {
 	log := r.Log
 	ctx := context.Background()
 
@@ -103,8 +103,22 @@ func createManagedCluster(r *ClusterClaimsReconciler, target string, labels map[
 		log.V(INFO).Info("Create a new ManagedCluster resource")
 		mc.Name = target
 		mc.Spec.HubAcceptsClient = true
-		mc.ObjectMeta.Labels = map[string]string{"vendor": "OpenShift"}
-		mc.Labels = labels
+
+		// Build the labels
+		newLabels := map[string]string{}
+		if labels != nil {
+			for key, val := range labels {
+				newLabels[key] = val
+			}
+		}
+
+		// Use the ClusterClaim name instead of the actual cluster name if a name was not included from the ClusterClaim
+		if _, ok := newLabels["name"]; !ok {
+			newLabels["name"] = claimName
+		}
+		newLabels["vendor"] = "OpenShift" // This is always true
+		//TODO: Add region lookup. It is a label on the ClusterDeployment or ClusterPool
+		mc.ObjectMeta.Labels = labels
 
 		if err = r.Create(ctx, &mc, &client.CreateOptions{}); err != nil {
 
@@ -134,7 +148,6 @@ func createKlusterletAddonConfig(r *ClusterClaimsReconciler, target string) (ctr
 		kac.Namespace = target
 		kac.Spec.ClusterName = target
 		kac.Spec.ClusterNamespace = target
-		kac.Spec.ClusterLabels = map[string]string{"vendor": "OpenShift"}
 		kac.Spec.ApplicationManagerConfig.Enabled = true
 		kac.Spec.CertPolicyControllerConfig.Enabled = true
 		kac.Spec.IAMPolicyControllerConfig.Enabled = true

--- a/controllers/clusterclaims/clusterclaims-controller_test.go
+++ b/controllers/clusterclaims/clusterclaims-controller_test.go
@@ -96,10 +96,6 @@ func TestReconcileClusterClaims(t *testing.T) {
 	err = ccr.Client.Get(ctx, getNamespaceName("", CLUSTER01), &mc)
 	assert.Nil(t, err, "nil, when managedCluster resource is retrieved")
 
-	assert.Equal(t, mc.Labels["name"], CC_NAME, "label name should equal clusterClaim name")
-	assert.Equal(t, mc.Labels["vendor"], "OpenShift", "label vendor should equal OpenShift")
-	assert.Equal(t, mc.Labels["usage"], "production", "label usage should equal production")
-
 	var kac kacv1.KlusterletAddonConfig
 	err = ccr.Client.Get(ctx, getNamespaceName(CLUSTER01, CLUSTER01), &kac)
 	assert.Nil(t, err, "nil, when klusterletAddonConfig resource is retrieved")

--- a/controllers/clusterclaims/clusterclaims-controller_test.go
+++ b/controllers/clusterclaims/clusterclaims-controller_test.go
@@ -57,6 +57,9 @@ func GetClusterClaim(namespace string, name string, clusterName string) *hivev1.
 		ObjectMeta: v1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Labels: map[string]string{
+				"usage": "production",
+			},
 		},
 		Spec: hivev1.ClusterClaimSpec{
 			ClusterPoolName: "make-believe",
@@ -93,12 +96,42 @@ func TestReconcileClusterClaims(t *testing.T) {
 	err = ccr.Client.Get(ctx, getNamespaceName("", CLUSTER01), &mc)
 	assert.Nil(t, err, "nil, when managedCluster resource is retrieved")
 
+	assert.Equal(t, mc.Labels["name"], CC_NAME, "label name should equal clusterClaim name")
+	assert.Equal(t, mc.Labels["vendor"], "OpenShift", "label vendor should equal OpenShift")
+	assert.Equal(t, mc.Labels["usage"], "production", "label usage should equal production")
+
 	var kac kacv1.KlusterletAddonConfig
 	err = ccr.Client.Get(ctx, getNamespaceName(CLUSTER01, CLUSTER01), &kac)
 	assert.Nil(t, err, "nil, when klusterletAddonConfig resource is retrieved")
 
 }
 
+func TestReconcileClusterClaimsLabelCopy(t *testing.T) {
+
+	ctx := context.Background()
+
+	ccr := GetClusterClaimsReconciler()
+
+	ccr.Client.Create(ctx, GetClusterClaim(CC_NAMESPACE, CC_NAME, CLUSTER01), &client.CreateOptions{})
+
+	_, err := ccr.Reconcile(getRequest())
+
+	assert.Nil(t, err, "nil, when clusterClaim is found reconcile was successful")
+
+	var mc mcv1.ManagedCluster
+	err = ccr.Client.Get(ctx, getNamespaceName("", CLUSTER01), &mc)
+	assert.Nil(t, err, "nil, when managedCluster resource is retrieved")
+
+	assert.Equal(t, mc.Labels["name"], CC_NAME, "label name should equal clusterClaim name")
+	assert.Equal(t, mc.Labels["vendor"], "OpenShift", "label vendor should equal OpenShift")
+	assert.Equal(t, mc.Labels["usage"], "production", "label usage should equal production")
+
+	var kac kacv1.KlusterletAddonConfig
+	err = ccr.Client.Get(ctx, getNamespaceName(CLUSTER01, CLUSTER01), &kac)
+	assert.Nil(t, err, "nil, when klusterletAddonConfig resource is retrieved")
+
+	assert.Equal(t, kac.Spec.ClusterLabels["vendor"], "OpenShift", "Check clusterLabels set")
+}
 func TestReconcileExistingManagedCluster(t *testing.T) {
 
 	ctx := context.Background()


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

* Labels were not being transferred as expected, fix how the labels for the ManagedCluster are built.
* Include `vendor` & `name`

**TODO:**
* Add support for `region` label