### PR TITLE
Add annotation open-cluster-management.io/createmanagedcluster: true/…

### DIFF
--- a/controllers/clusterclaims/clusterclaims-controller.go
+++ b/controllers/clusterclaims/clusterclaims-controller.go
@@ -4,6 +4,7 @@ package clusterlcaims
 
 import (
 	"context"
+	"strings"
 
 	"github.com/go-logr/logr"
 	mcv1 "github.com/open-cluster-management/api/cluster/v1"
@@ -25,6 +26,7 @@ const INFO = 0
 const WARN = -1
 const ERROR = -2
 const FINALIZER = "clusterclaims-controller.open-cluster-management.io/cleanup"
+const CREATECM = "open-cluster-management.io/createmanagedcluster"
 
 // ClusterClaimsReconciler reconciles a clusterClaim
 type ClusterClaimsReconciler struct {
@@ -62,6 +64,12 @@ func (r *ClusterClaimsReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 		}
 
 		return ctrl.Result{}, removeFinalizer(r, &cc)
+	}
+
+	// Do not exit till this point when importmanagedcluster=false, so deletion will work properly if manually imported
+	if strings.ToLower(cc.Annotations["open-cluster-management.io/createmanagedcluster"]) == "false" {
+		log.V(WARN).Info("Skip creation of managedCluster and KlusterletAddonConfig")
+		return ctrl.Result{}, nil
 	}
 
 	// ManagedCluster

--- a/controllers/clusterclaims/clusterclaims-controller.go
+++ b/controllers/clusterclaims/clusterclaims-controller.go
@@ -67,9 +67,12 @@ func (r *ClusterClaimsReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 	}
 
 	// Do not exit till this point when importmanagedcluster=false, so deletion will work properly if manually imported
-	if strings.ToLower(cc.Annotations["open-cluster-management.io/createmanagedcluster"]) == "false" {
-		log.V(WARN).Info("Skip creation of managedCluster and KlusterletAddonConfig")
-		return ctrl.Result{}, nil
+	if len(cc.Annotations) > 0 {
+		aValue, found := cc.Annotations["open-cluster-management.io/createmanagedcluster"]
+		if found && strings.ToLower(aValue) == "false" {
+			log.V(WARN).Info("Skip creation of managedCluster and KlusterletAddonConfig")
+			return ctrl.Result{}, nil
+		}
 	}
 
 	// ManagedCluster


### PR DESCRIPTION
…false/<empty>

Signed-off-by: Joshua Packer <jpacker@redhat.com>

* Add annotation flag to disable creation of ManagedCluster and KlusterletAddonConfig resource.
* Maintain deletion of these resources when removing the cluster claim. (Since the cluster will be deleted)

FYI @gurnben For Collective.